### PR TITLE
Add due time display for Todoist tasks

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -113,7 +113,15 @@ async fn adb() -> anyhow::Result<()> {
     w.underline(false).await?;
 
     for todo in todo_items {
-        w.write_all(format!("[ ] {}\n", todo).as_bytes()).await?;
+        w.write_all(b"[ ] ").await?;
+        if let Some(time) = todo.time {
+            w.emphasize(true).await?;
+            w.write_all(format!("{}", time.format("%-I:%M %p")).as_bytes())
+                .await?;
+            w.emphasize(false).await?;
+            w.write_all(b" ").await?;
+        }
+        w.write_all(format!("{}\n", todo.content).as_bytes()).await?;
     }
 
     w.feed(2).await?;

--- a/src/todoist.rs
+++ b/src/todoist.rs
@@ -6,12 +6,33 @@ struct TodoistResponse {
 #[derive(serde::Deserialize)]
 struct TodoistTask {
     content: String,
+    due: Option<TodoistDue>,
+}
+
+#[derive(serde::Deserialize)]
+struct TodoistDue {
+    date: String,
+}
+
+pub struct TodoItem {
+    pub content: String,
+    pub time: Option<chrono::NaiveTime>,
+}
+
+fn parse_due_time(s: &str) -> Option<chrono::NaiveTime> {
+    if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(s) {
+        return Some(dt.with_timezone(&chrono::Local).time());
+    }
+    if let Ok(dt) = chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S%.f") {
+        return Some(dt.time());
+    }
+    None
 }
 
 pub async fn get_todo_items(
     client: &reqwest::Client,
     api_token: &str,
-) -> anyhow::Result<Vec<String>> {
+) -> anyhow::Result<Vec<TodoItem>> {
     let response = client
         .get("https://api.todoist.com/api/v1/tasks/filter?query=od%20%7C%20due%3Atoday")
         .bearer_auth(api_token)
@@ -30,6 +51,9 @@ pub async fn get_todo_items(
         .await?
         .results
         .into_iter()
-        .map(|t| t.content)
+        .map(|t| TodoItem {
+            content: t.content,
+            time: t.due.as_ref().and_then(|d| parse_due_time(&d.date)),
+        })
         .collect())
 }


### PR DESCRIPTION
## Summary
Enhanced the Todoist integration to parse and display task due times. Tasks with due dates now show their scheduled time in emphasized text before the task content.

## Key Changes
- Added `TodoistDue` struct to deserialize due date information from Todoist API responses
- Created `TodoItem` public struct to represent tasks with optional due time information
- Implemented `parse_due_time()` function to parse due dates in RFC3339 and custom datetime formats, extracting the time component
- Updated `get_todo_items()` return type from `Vec<String>` to `Vec<TodoItem>` to include time data
- Modified task rendering in `adb()` to display due times in emphasized text (12-hour format with AM/PM) before task content

## Implementation Details
- Due time parsing supports both RFC3339 format (with timezone conversion to local) and a custom `%Y-%m-%dT%H:%M:%S%.f` format
- Time is displayed using 12-hour format (`%-I:%M %p`) for better readability
- Emphasized formatting is applied only when a due time is present
- The change maintains backward compatibility by using `Option<chrono::NaiveTime>` for optional due times

https://claude.ai/code/session_01RN7mpaPQBPEiK9oVDU6pbM